### PR TITLE
deactivate unnecessary bytemuck features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.8.0"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["que", "examples/*"]
 resolver = "2"
 
 [workspace.dependencies]
-bytemuck = { version = "1.16.3", features = ["derive", "min_const_generics"] }
+bytemuck = { version = "1.16.3" }
 nix = { version = "0.29", features = [
     "event",
     "poll",

--- a/examples/benchmark/Cargo.toml
+++ b/examples/benchmark/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bytemuck = { workspace = true }
+bytemuck = { workspace = true, features = ["derive", "min_const_generics"] }
 nix = { workspace = true }
 que = { workspace = true }

--- a/que/Cargo.toml
+++ b/que/Cargo.toml
@@ -14,6 +14,7 @@ bytemuck = { workspace = true }
 nix = { workspace = true }
 
 [dev-dependencies]
+bytemuck = { workspace = true, features = ["derive", "min_const_generics"] }
 criterion = "0.5.1"
 
 


### PR DESCRIPTION
The `que` crate doesn't need the bytemuck features that it activates