### PR TITLE
Cache Atomic head For Producer, Cache Atomic tail for Consumer.

### DIFF
--- a/que/src/lossless/producer.rs
+++ b/que/src/lossless/producer.rs
@@ -265,11 +265,9 @@ impl<M: ChannelMode<T>, T, const N: usize> Producer<M, T, N> {
         self.tail += 1;
         self.written += 1;
 
-        // // Update tail if we've written past burst amount and haven't
-        // // updated shared atomic.
-        // if self.written == burst_amount::<N>() {
-        //     self.sync();
-        // }
+        if self.written == burst_amount::<N>() {
+            self.sync();
+        }
 
         Ok(())
     }
@@ -349,21 +347,17 @@ impl<M: ChannelMode<T>, T, const N: usize> Producer<M, T, N> {
             return Err(QueError::InvalidSize);
         }
 
-        // Check if we have space
-        let head = if self.tail == self.head_cache + N {
+        let mut available_space = N - (self.tail - self.head_cache);
+        if count > available_space {
             self.head_cache = unsafe {
                 (*self.spsc.as_ptr())
                     .head
                     .load(Ordering::Acquire)
             };
-            self.head_cache
-        } else {
-            self.head_cache
-        };
-
-        let available_space = N - (self.tail - head);
-        if count > available_space {
-            return Err(QueError::Full);
+            available_space = N - (self.tail - self.head_cache);
+            if count > available_space {
+                return Err(QueError::Full);
+            }
         }
 
         Ok(Reservation {

--- a/que/src/lossless/producer.rs
+++ b/que/src/lossless/producer.rs
@@ -14,6 +14,7 @@ use super::{burst_amount, Channel};
 pub struct Producer<M: ChannelMode<T>, T, const N: usize> {
     spsc: NonNull<Channel<M, T, N>>,
     tail: usize,
+    head_cache: usize,
     /// Number of elements written since last sync
     written: usize,
     last_consumer_heartbeat: usize,
@@ -67,6 +68,7 @@ impl<T: AnyBitPattern, const N: usize> Producer<ShmemMode, T, N> {
             Ok(Producer {
                 spsc: NonNull::new(shmem.get_mut_ptr().cast()).unwrap(),
                 tail: (*spsc).tail.load(Ordering::Acquire),
+                head_cache: (*spsc).head.load(Ordering::Acquire),
                 written: 0,
                 last_consumer_heartbeat: (*spsc)
                     .consumer_heartbeat
@@ -82,6 +84,7 @@ impl<T: AnyBitPattern, const N: usize> Producer<ShmemMode, T, N> {
             Ok(Producer {
                 spsc: NonNull::new(shmem.get_mut_ptr().cast()).unwrap(),
                 tail: 0,
+                head_cache: 0,
                 written: 0,
                 last_consumer_heartbeat: (*spsc)
                     .consumer_heartbeat
@@ -154,6 +157,7 @@ impl<M: ChannelMode<T>, T, const N: usize> Producer<M, T, N> {
             Ok(Producer {
                 spsc: NonNull::new(buffer.cast()).unwrap(),
                 tail: (*spsc).tail.load(Ordering::Acquire),
+                head_cache: (*spsc).head.load(Ordering::Acquire),
                 written: 0,
                 last_consumer_heartbeat: (*spsc)
                     .consumer_heartbeat
@@ -175,6 +179,7 @@ impl<M: ChannelMode<T>, T, const N: usize> Producer<M, T, N> {
             Ok(Producer {
                 spsc: NonNull::new(buffer.cast()).unwrap(),
                 tail: 0,
+                head_cache: 0,
                 written: 0,
                 last_consumer_heartbeat: (*spsc)
                     .consumer_heartbeat
@@ -215,6 +220,7 @@ impl<M: ChannelMode<T>, T, const N: usize> Producer<M, T, N> {
             Ok(Producer {
                 spsc: NonNull::new(buffer.cast()).unwrap(),
                 tail: (*spsc).tail.load(Ordering::Acquire),
+                head_cache: (*spsc).head.load(Ordering::Acquire),
                 written: 0,
                 last_consumer_heartbeat: (*spsc)
                     .consumer_heartbeat
@@ -235,14 +241,15 @@ impl<M: ChannelMode<T>, T, const N: usize> Producer<M, T, N> {
     #[inline(always)]
     pub fn push(&mut self, value: T) -> Result<(), QueError> {
         // Check if full
-        let is_full = self.tail
-            == unsafe {
+        if self.tail == self.head_cache + N {
+            self.head_cache = unsafe {
                 (*self.spsc.as_ptr())
                     .head
                     .load(Ordering::Acquire)
-            } + N;
-        if is_full {
-            return Err(QueError::Full);
+            };
+            if self.tail == self.head_cache + N {
+                return Err(QueError::Full);
+            }
         }
 
         // Write value if not full
@@ -343,10 +350,15 @@ impl<M: ChannelMode<T>, T, const N: usize> Producer<M, T, N> {
         }
 
         // Check if we have space
-        let head = unsafe {
-            (*self.spsc.as_ptr())
-                .head
-                .load(Ordering::Acquire)
+        let head = if self.tail == self.head_cache + N {
+            self.head_cache = unsafe {
+                (*self.spsc.as_ptr())
+                    .head
+                    .load(Ordering::Acquire)
+            };
+            self.head_cache
+        } else {
+            self.head_cache
         };
 
         let available_space = N - (self.tail - head);


### PR DESCRIPTION
On an humble Macbook Air, `cargo bench -p que`:

## Post-Commit

```sh
Gnuplot not found, using plotters backend
Unmapping shared memory: sh_bench
Closing shared memory: sh_bench
fd closed: sh_bench
PushPop/push_pop        time:   [59.597 ns 62.966 ns 66.447 ns]
                        thrpt:  [17.268 GiB/s 18.222 GiB/s 19.253 GiB/s]
                 change:
                        time:   [-16.057% -12.544% -8.6592%] (p = 0.00 < 0.05)
                        thrpt:  [+9.4801% +14.343% +19.129%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

StdSyncMpsc/send_recv   time:   [758.35 ns 786.76 ns 817.62 ns]
                        thrpt:  [1.4033 GiB/s 1.4584 GiB/s 1.5130 GiB/s]
                 change:
                        time:   [-12.263% -8.0734% -3.8437%] (p = 0.00 < 0.05)
                        thrpt:  [+3.9973% +8.7825% +13.977%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high mild
  ```
  
  ### Pre-Commit
  
```sh
Gnuplot not found, using plotters backend
Unmapping shared memory: sh_bench
Closing shared memory: sh_bench
fd closed: sh_bench
PushPop/push_pop        time:   [74.686 ns 78.203 ns 82.151 ns]
                        thrpt:  [13.967 GiB/s 14.672 GiB/s 15.363 GiB/s]
                 change:
                        time:   [+38.414% +45.614% +52.591%] (p = 0.00 < 0.05)
                        thrpt:  [-34.465% -31.325% -27.753%]
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

StdSyncMpsc/send_recv   time:   [836.24 ns 876.46 ns 919.18 ns]
                        thrpt:  [1.2483 GiB/s 1.3091 GiB/s 1.3721 GiB/s]
                 change:
                        time:   [+8.7913% +13.450% +18.625%] (p = 0.00 < 0.05)
                        thrpt:  [-15.701% -11.856% -8.0809%]
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
```